### PR TITLE
[R+M]: RHv2, Repeating Timer Fix

### DIFF
--- a/src/components/Display/display.js
+++ b/src/components/Display/display.js
@@ -16,7 +16,8 @@ class Display extends Component {
 
     componentDidUpdate() {
 
-        this.updateIndexEvery(20000)
+        this.timeoutId !== undefined && clearInterval(this.timeoutId)
+        this.timeoutId = this.updateIndexEvery(20000)
 
     }
 


### PR DESCRIPTION
`componentDidUpdate()` in `Display`  was being trigger each time a button was clicked causing many timers that cycle to the next image to be created.

* This fix allows one active timer.