### PR TITLE
[R&M]: Fix issue with gif duration by removing gif-me-info and replacing with gify-parse.

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Reddit humor is a fun internal web app intended to be displayed on a communal mo
 ### Additional Dependencies
  * icons: [react-feather](https://github.com/carmelopullara/react-feather)
  * design: [tachyons](https://tachyons.io/) 
- * gif duration extraction: [gif-me-info](https://github.com/STRsplit/gif-me-info)
+ * gif duration extraction: [gify-parse](https://github.com/JonasHavers/node-gify-parse)
  
 ### Contribution
  * Check open issues or file a new one, PR's are always welcome!

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
-    "gif-me-info": "^1.0.1",
+    "gify-parse": "^1.0.7",
     "isomorphic-fetch": "^2.2.1",
     "prop-types": "^15.6.2",
     "react": "^16.4.1",

--- a/src/components/Display/display.js
+++ b/src/components/Display/display.js
@@ -14,10 +14,8 @@ class Display extends Component {
     }
 
     componentDidUpdate() {
-
         this.timeoutId !== undefined && clearInterval(this.timeoutId)
         this.timeoutId = this.updateIndexEvery(20000)
-
     }
 
     render() {
@@ -40,12 +38,12 @@ class Display extends Component {
 
     }
 
-    updateIndexEvery = (ms) => {
+    updateIndexEvery = async (ms) => {
 
         const  {images, current, setCurrentIndex} = this.props
         const image = images[current]
 
-        const time = image.gif ? getGifDuration(image.url) + ms : ms
+        const time = image.gif ? await getGifDuration(image.url) + ms : ms
 
         return setTimeout(() => {
 

--- a/src/components/Display/display.js
+++ b/src/components/Display/display.js
@@ -6,8 +6,7 @@ import getGifDuration from '../../utils/gifDuration'
 import {getNextIndex} from '../../utils/getNextIndex'
 
 class Display extends Component {
-
-
+    
     async componentDidMount() {
 
         await this.getHumorEvery(3600000)
@@ -15,7 +14,7 @@ class Display extends Component {
     }
 
     componentDidUpdate() {
-
+        
         this.updateIndexEvery(20000)
 
     }

--- a/src/components/Display/display.js
+++ b/src/components/Display/display.js
@@ -14,8 +14,10 @@ class Display extends Component {
     }
 
     componentDidUpdate() {
+
         this.timeoutId !== undefined && clearInterval(this.timeoutId)
         this.timeoutId = this.updateIndexEvery(20000)
+        
     }
 
     render() {

--- a/src/utils/gifDuration.js
+++ b/src/utils/gifDuration.js
@@ -1,7 +1,8 @@
-import gifInfo from 'gif-me-info'
+import gifyParse from 'gify-parse'; 
 
-export default async function getGifDuration (url) {
-    const gif = [url]
-    const result = await gifInfo(gif)
-    return result[0].duration
+export default async function getGifDuration(url) {
+    const data = await fetch(url)
+    const buffer = await data.arrayBuffer()
+    const pictureDataInBinary = Buffer.from(buffer, 'base64')
+    return gifyParse.getInfo(pictureDataInBinary).duration
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3683,7 +3683,7 @@ gif-me-info@^1.0.1:
     axios "^0.16.2"
     gify-parse "^1.0.6"
 
-gify-parse@^1.0.6:
+gify-parse@^1.0.6, gify-parse@^1.0.7:
   version "1.0.7"
   resolved "https://registry.yarnpkg.com/gify-parse/-/gify-parse-1.0.7.tgz#d562608c297834f03c5206b5a673c8d62956c163"
   dependencies:


### PR DESCRIPTION
gif-me-info had issues with the code. Since the library relied on both gify-parse and axios, lets just use that library to solve that issue.

Also fixed the async issue where getGifDuration was returning a promise instead of a duration.

Also updated readme...